### PR TITLE
Corrected embed link

### DIFF
--- a/lib/Controller/PageController.php
+++ b/lib/Controller/PageController.php
@@ -34,7 +34,7 @@ use OCP\IUserSession;
 
 class PageController extends Controller {
 
-	const SERVERURL = 'https://www.draw.io';
+	const SERVERURL = 'https://embed.diagrams.net';
 	const THEME = 'minimal';
 
 	/** @var IRootFolder  */

--- a/templates/editor.php
+++ b/templates/editor.php
@@ -44,7 +44,7 @@ style('drawio', 'editor');
 		OCA.Drawio.LoadEventHandler(
 			$('#drawioEditor')[0].contentWindow,
 			'<?php echo urldecode($_['path']); ?>',
-			'https://www.draw.io'
+			'https://embed.diagrams.net'
 		);
 	});
 </script>


### PR DESCRIPTION
Using www.draw.io redirects to app.diagrams.net, which doesn't allow iFrame embedding. embed.diagrams.net is the correct URL to use.